### PR TITLE
Tweak CI Jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,13 @@ on:
 
 jobs:
   test:
-    name: Tests
-    runs-on: ${{ matrix.os }}
+    name: "Node ${{ matrix.node }} - ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}-latest
 
     strategy:
       matrix:
-        node: ['12', 'latest']
-        os: [ubuntu-latest, macOS-latest, windows-latest]
+        node: ['12', '14', 'latest']
+        os: [ubuntu, macOS, windows]
 
     steps:
     - uses: actions/checkout@v1
@@ -27,7 +27,7 @@ jobs:
       with:
         node-version: ${{ matrix.node }}
     - name: install dependencies
-      run: yarn
+      run: yarn --frozen-lockfile
     - name: lint
       run: yarn lint
       env:
@@ -38,3 +38,23 @@ jobs:
       env:
         NODE_OPTIONS: --experimental-modules
         CI: true
+
+  floating-dependencies:
+    name: "Floating Dependencies"
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - uses: volta-cli/action@v1
+      with:
+        node-version: latest
+    - name: install dependencies
+      run: yarn --no-lockfile
+    - name: lint
+      run: yarn lint
+      env:
+        NODE_OPTIONS: --experimental-modules
+    - name: test
+      run: yarn test
+      env:
+        NODE_OPTIONS: --experimental-modules


### PR DESCRIPTION
* Tweak test job name titles
* Add Node 14
* Remove manual CI=true (it is done by default for GH Actions now)
* Add new `floating-dependencies` CI job as an early warning detection